### PR TITLE
Replace channels.info with conversations.info

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -202,7 +202,7 @@ function get_channel( $id ) {
 	}
 
 	$data = request(
-		'channels.info',
+		'conversations.info',
 		[
 			'channel' => $id,
 		]


### PR DESCRIPTION
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api